### PR TITLE
Fix argument type (expected string, given symbol)

### DIFF
--- a/introduction-to-builtin-modes.md
+++ b/introduction-to-builtin-modes.md
@@ -560,7 +560,7 @@
     "SPDX-License-Identifier: " (completing-read "License: "
                                                  license-spdx-identifiers)
     comment-end > n>)
-  'license
+  "license"
   "Insert a SPDX license.")
 ```
 


### PR DESCRIPTION
#### For details, check `tempo-complete-tag` function

```elisp
(defun tempo-complete-tag (&optional silent)
  (let* ((collection (tempo-build-collection))
         (match-info (tempo-find-match-string tempo-match-finder))
         (match-string (car match-info))
         (match-start (cdr match-info))
         (exact (assoc match-string collection)))
    ...))
```

#### `COLLECTION` is expected to be following structure:

   ```elisp
   ((TAG-str . tempo-template-FUNCTION) ...)
   ```

#### tldr;
Look at the code `(assoc match-string collection)` in the body of
function `tempo-complete-tag`